### PR TITLE
Feature/allow other s3 buckets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,44 +44,41 @@ resource "aws_iam_policy" "this" {
   count       = var.create_sftp_server ? 1 : 0
   description = "Access Policy for S3 - AWS Transfer Family Service Role."
   name        = "${var.name_prefix}-${var.namespace}-iam-policy"
-  policy      = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "CloudWatchLogsAccess",
-      "Effect": "Allow",
-      "Action": [
-        "logs:*"
-      ],
-      "Resource": "arn:aws:logs:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:log-group:/aws/transfer/${aws_transfer_server.sftp[count.index].id}"
-    },
-    {
-      "Sid": "S3ListBuckets",
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket"
-      ],
-      "Resource": ${var.s3_access_buckets}
-    },
-    {
-      "Sid": "S3BucketObjects",
-      "Effect": "Allow",
-      "Action": [
-        "s3:PutObject",
-        "s3:GetObject",
-        "s3:DeleteObject",
-        "s3:DeleteObjectVersion",
-        "s3:GetObjectVersion",
-        "s3:GetObjectACL",
-        "s3:PutObjectACL"
-      ],
-      "Resource": ${var.s3_access_objects}
-    }
-  ]
-}
-EOF
-
+  policy      = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid = "CloudWatchLogsAccess",
+        Effect = "Allow",
+        Action = [
+          "logs:*"
+        ],
+        Resource = "arn:aws:logs:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:log-group:/aws/transfer/${aws_transfer_server.sftp[count.index].id}"
+      },
+      {
+        Sid = "S3ListBuckets",
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket"
+        ],
+        Resource = var.s3_access_buckets
+      },
+      {
+        Sid = "S3BucketObjects",
+        Effect = "Allow",
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:DeleteObjectVersion",
+          "s3:GetObjectVersion",
+          "s3:GetObjectACL",
+          "s3:PutObjectACL"
+        ],
+        Resource = var.s3_access_objects
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "this" {

--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,12 @@ resource "aws_transfer_server" "sftp" {
     var.tags
   )
 
+  lifecycle {
+    ignore_changes = [
+      security_policy_name,
+    ]
+  }
+
   # Adding this to mimic behavior from AWS Console.
   # Option currently not available as Terraform input.
   provisioner "local-exec" {

--- a/main.tf
+++ b/main.tf
@@ -62,9 +62,7 @@ resource "aws_iam_policy" "this" {
       "Action": [
         "s3:ListBucket"
       ],
-      "Resource": [
-        "arn:aws:s3:::${aws_s3_bucket.this[count.index].id}"
-      ]
+      "Resource": ${var.s3_access_buckets}
     },
     {
       "Sid": "S3BucketObjects",
@@ -78,9 +76,7 @@ resource "aws_iam_policy" "this" {
         "s3:GetObjectACL",
         "s3:PutObjectACL"
       ],
-      "Resource": [
-        "arn:aws:s3:::${aws_s3_bucket.this[count.index].id}/*"
-      ]
+      "Resource": ${var.s3_access_objects}
     }
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,6 +9,10 @@ output "s3_bucket_id" {
   value = element(aws_s3_bucket.this.*.id, 0)
 }
 
+output "s3_bucket_arn" {
+  value = element(aws_s3_bucket.this.*.arn, 0)
+}
+
 # Transfer Server
 output "server_arn" {
   value = element(aws_transfer_server.sftp.*.id, 0)

--- a/variables.tf
+++ b/variables.tf
@@ -54,13 +54,6 @@ variable "s3_force_destroy" {
   default     = false
 }
 
-locals {
-
-  s3_access_to_buckets = [
-    "arn:aws:s3:::${var.s3_access_to_buckets}/*"
-  ]
-}
-
 variable "s3_versioning" {
   description = "Enable versioning."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -26,10 +26,20 @@ variable "log_retention" {
 }
 
 # S3
-variable "s3_acl" {
-  description = "Canned ACL to apply on S3 Bucket."
-  type        = string
-  default     = "private"
+variable "s3_access_buckets" {
+  description = "A list of ARNs for s3 buckets that the transfer server has access to."
+  type        = list(string)
+  default     = [
+    "arn:aws:s3:::*"
+  ]
+}
+
+variable "s3_access_objects" {
+  description = "A list of ARNs for s3 bucket objects that the transfer server has access to."
+  type        = list(string)
+  default     = [
+    "arn:aws:s3:::*/*"
+  ]
 }
 
 variable "s3_disable_public_access" {
@@ -42,6 +52,13 @@ variable "s3_force_destroy" {
   description = "A boolean that indicates all objects (including any locked objects) should be deleted from the bucket so that the bucket can be destroyed without error."
   type        = bool
   default     = false
+}
+
+locals {
+
+  s3_access_to_buckets = [
+    "arn:aws:s3:::${var.s3_access_to_buckets}/*"
+  ]
 }
 
 variable "s3_versioning" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "s3_access_objects" {
   ]
 }
 
+variable "s3_acl" {
+  description = "Canned ACL to apply on S3 Bucket."
+  type        = string
+  default     = "private"
+}
+
 variable "s3_disable_public_access" {
   description = "Enable/disable public access on s3 bucket. By default public access blocked."
   type        = bool


### PR DESCRIPTION
- Allow input(s) for specifying other s3 buckets that the transfer server will have access to write to.